### PR TITLE
Актуализированы модели авторизации

### DIFF
--- a/src/Yandex.Music.Api/API/YUserAPI.cs
+++ b/src/Yandex.Music.Api/API/YUserAPI.cs
@@ -412,10 +412,7 @@ namespace Yandex.Music.Api.API
                 .Build(password)
                 .GetResponseAsync();
 
-            // if (response.Status != YAuthStatus.Ok || !string.IsNullOrWhiteSpace(response.RedirectUrl))
-            //     throw new AuthenticationException("Ошибка авторизации.");
-
-            if (response.Status == YAuthStatus.Ok && response.Errors == null)
+            if (response.Status == YAuthStatus.Ok)
             {
                 bool ok = await LoginByCookiesAsync(storage);
                 if (!ok)

--- a/src/Yandex.Music.Api/API/YUserAPI.cs
+++ b/src/Yandex.Music.Api/API/YUserAPI.cs
@@ -424,7 +424,7 @@ namespace Yandex.Music.Api.API
                 }
             }
 
-            return response; // TODO: make
+            return response;
         }
 
         /// <summary>

--- a/src/Yandex.Music.Api/Models/Account/YAuthBase.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthBase.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Yandex.Music.Api.Models.Account
 {
@@ -8,5 +9,7 @@ namespace Yandex.Music.Api.Models.Account
 
         [JsonProperty("redirect_url")]
         public string RedirectUrl { get; set; }
+        
+        public List<YAuthError> Errors { get; set; }
     }
 }

--- a/src/Yandex.Music.Api/Models/Account/YAuthCaptcha.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthCaptcha.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Yandex.Music.Api.Models.Account
 {
@@ -6,11 +7,25 @@ namespace Yandex.Music.Api.Models.Account
     {
         public string Id { get; set; }
 
+        public string Name { get; set; }
+        
+        public string Label { get; set; }
+        
+        public string Mode { get; set; }
+        
+        public List<YAuthCaptchaError> Error { get; set; }
+
+        public bool CountryFromAudioWhiteList { get; set; }
+        
+        public YAuthCaptchaOptions Options { get; set; }
+        
+        public YAuthCaptchaVoice Voice { get; set; }
+
         [JsonProperty("image_url")]
         public string ImageUrl { get; set; }
 
         public string Key { get; set; }
 
-        public YAuthCaptchaVoice Voice { get; set; }
+        public string Static { get; set; }
     }
 }

--- a/src/Yandex.Music.Api/Models/Account/YAuthCaptchaError.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthCaptchaError.cs
@@ -1,0 +1,8 @@
+namespace Yandex.Music.Api.Models.Account
+{
+    public class YAuthCaptchaError
+    {
+        public string Message { get; set; }
+        public YAuthCaptchaErrorCode Code { get; set; }
+    }
+}

--- a/src/Yandex.Music.Api/Models/Account/YAuthCaptchaErrorCode.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthCaptchaErrorCode.cs
@@ -1,14 +1,9 @@
-using System.Runtime.Serialization;
-
 namespace Yandex.Music.Api.Models.Account
 {
     public enum YAuthCaptchaErrorCode
     {
-        [EnumMember(Value = "missingvalue")]
         MissingValue,
-        [EnumMember(Value = "captchalocate")]
         CaptchaLocate,
-        [EnumMember(Value = "incorrect")]
         Incorrect
     }
 }

--- a/src/Yandex.Music.Api/Models/Account/YAuthCaptchaErrorCode.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthCaptchaErrorCode.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace Yandex.Music.Api.Models.Account
+{
+    public enum YAuthCaptchaErrorCode
+    {
+        [EnumMember(Value = "missingvalue")]
+        MissingValue,
+        [EnumMember(Value = "captchalocate")]
+        CaptchaLocate,
+        [EnumMember(Value = "incorrect")]
+        Incorrect
+    }
+}

--- a/src/Yandex.Music.Api/Models/Account/YAuthCaptchaOptions.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthCaptchaOptions.cs
@@ -1,0 +1,7 @@
+namespace Yandex.Music.Api.Models.Account
+{
+    public class YAuthCaptchaOptions
+    {
+        public bool AsyncCheck { get; set; }
+    }
+}

--- a/src/Yandex.Music.Api/Models/Account/YAuthError.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthError.cs
@@ -1,0 +1,20 @@
+using System.Runtime.Serialization;
+
+namespace Yandex.Music.Api.Models.Account
+{
+    public enum YAuthError
+    {
+        [EnumMember(Value = "authorization.invalid")]
+        AuthorizationInvalid,
+        [EnumMember(Value = "sessionid.invalid")]
+        SessionIdInvalid,
+        [EnumMember(Value = "password.not_matched")]
+        PasswordNotMatched,
+        [EnumMember(Value = "password.empty")]
+        PasswordEmpty,
+        [EnumMember(Value = "captcha.required")]
+        CaptchaRequired,
+        [EnumMember(Value = "captcha.not_matched")]
+        CaptchaNotMatched
+    }
+}

--- a/src/Yandex.Music.Api/Models/Account/YAuthQrStatus.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthQrStatus.cs
@@ -15,5 +15,7 @@ namespace Yandex.Music.Api.Models.Account
         public string Id { get; set; }
 
         public string State { get; set; }
+        
+        public YAuthCaptcha Captcha { get; set; }
     }
 }

--- a/src/Yandex.Music.Api/Models/Account/YAuthStatus.cs
+++ b/src/Yandex.Music.Api/Models/Account/YAuthStatus.cs
@@ -2,6 +2,7 @@
 {
     public enum YAuthStatus
     {
-        Ok
+        Ok,
+        Error
     }
 }

--- a/src/Yandex.Music.Client/YandexMusicClient.cs
+++ b/src/Yandex.Music.Client/YandexMusicClient.cs
@@ -85,9 +85,9 @@ namespace Yandex.Music.Client
             return api.User.GetCaptcha(storage);
         }
 
-        public void AuthorizeByCaptcha(string captcha)
+        public YAuthBase AuthorizeByCaptcha(string captcha)
         {
-            api.User.AuthorizeByCaptcha(storage, captcha);
+            return api.User.AuthorizeByCaptcha(storage, captcha);
         }
 
         public YAuthLetter GetAuthLetter()

--- a/src/Yandex.Music.Client/YandexMusicClient.cs
+++ b/src/Yandex.Music.Client/YandexMusicClient.cs
@@ -75,7 +75,7 @@ namespace Yandex.Music.Client
             return api.User.GetAuthQRLink(storage);
         }
 
-        public bool AuthorizeByQR()
+        public YAuthQRStatus AuthorizeByQR()
         {
             return api.User.AuthorizeByQR(storage);
         }
@@ -100,7 +100,7 @@ namespace Yandex.Music.Client
             return api.User.AuthorizeByLetter(storage);
         }
 
-        public bool AuthorizeByAppPassword(string password)
+        public YAuthBase AuthorizeByAppPassword(string password)
         {
             return api.User.AuthorizeByAppPassword(storage, password);
         }


### PR DESCRIPTION
Актуализированы модели авторизации (капча, авторизация по QR, OTP).

Теперь методы авторизации возвращают не булевы значения, а `YAuthBase` и производные от него, это позволяет производить более гибкую авторизацию, например, когда надо среагировать на требование ввода капчи при авторизации по OTP.

Для авторизации по почте всё оставил как есть, т.к. у меня нет аккаунта с данным типом авторизации.
