### PR TITLE
Добавлен YTrackSource OWN_REPLACED_TO_UGC

### DIFF
--- a/src/Yandex.Music.Api/Models/Common/YTrackSource.cs
+++ b/src/Yandex.Music.Api/Models/Common/YTrackSource.cs
@@ -10,6 +10,9 @@ namespace Yandex.Music.Api.Models.Common
         
         [EnumMember(Value = "UGC")]
         [Description("User Generated Content")]
-        UGC
+        UGC,
+        
+        [EnumMember(Value = "OWN_REPLACED_TO_UGC")]
+        OwnReplacedToUGC,
     }
 }


### PR DESCRIPTION
Несколько треков, например Kingslayer - BMTH, выдавали trackSource OWN_REPLACED_TO_UGC, который не был прописан в перечислении YTrackSource