### PR TITLE
Добавлены методы Artist.GetTracks и Artist.GetAllTracks

### DIFF
--- a/docs/source/api/branches/artist.rst
+++ b/docs/source/api/branches/artist.rst
@@ -16,3 +16,15 @@ YArtistAPI
    public Task<YResponse<List<YArtist>>> GetAsync(AuthStorage storage, IEnumerable<string> artistIds)
 
 Получение списка исполнителей.
+
+.. code-block:: csharp
+
+   public Task<YResponse<YTracksContainer>> GetTracksAsync(AuthStorage storage, string artistId, int page = 0, int pageSize = 20)
+
+Получение списка треков исполнителя с пагинацией.
+
+.. code-block:: csharp
+
+   public Task<YResponse<YTracksContainer>> GetAllTracksAsync(AuthStorage storage, string artistId)
+
+Получение списка всех треков исполнителя.

--- a/src/Yandex.Music.Api.Tests/Tests/API/ArtistAPITest.cs
+++ b/src/Yandex.Music.Api.Tests/Tests/API/ArtistAPITest.cs
@@ -8,6 +8,7 @@ using Xunit.Extensions.Ordering;
 
 using Yandex.Music.Api.Models.Artist;
 using Yandex.Music.Api.Models.Common;
+using Yandex.Music.Api.Models.Track;
 using Yandex.Music.Api.Tests.Traits;
 
 namespace Yandex.Music.Api.Tests.Tests.API
@@ -37,6 +38,22 @@ namespace Yandex.Music.Api.Tests.Tests.API
         {
             YResponse<List<YArtist>> artists = Fixture.API.Artist.Get(Fixture.Storage, new[] { "157479", "48814" });
             artists.Result.Count.Should().Be(2);
+        }
+
+        [Fact, YandexTrait(TraitGroup.ArtistAPI)]
+        [Order(2)]
+        public void GetTracks_ValidData_True()
+        {
+            YResponse<YTracksContainer> tracks = Fixture.API.Artist.GetTracks(Fixture.Storage, artistId, 1, 30);
+            tracks.Result.Tracks.Count.Should().Be(30);
+        }
+        
+        [Fact, YandexTrait(TraitGroup.ArtistAPI)]
+        [Order(3)]
+        public void GetAllTracks_ValidData_True()
+        {
+            YResponse<YTracksContainer> tracks = Fixture.API.Artist.GetAllTracks(Fixture.Storage, artistId);
+            tracks.Result.Tracks.Count.Should().BeGreaterThan(30);
         }
 
         public ArtistAPITest(YandexTestHarness fixture, ITestOutputHelper output) : base(fixture, output)

--- a/src/Yandex.Music.Api/API/YArtistAPI.cs
+++ b/src/Yandex.Music.Api/API/YArtistAPI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Yandex.Music.Api.Common;
 using Yandex.Music.Api.Models.Artist;
 using Yandex.Music.Api.Models.Common;
+using Yandex.Music.Api.Models.Track;
 
 namespace Yandex.Music.Api.API
 {
@@ -31,6 +32,33 @@ namespace Yandex.Music.Api.API
         public YResponse<List<YArtist>> Get(AuthStorage storage, IEnumerable<string> artistIds)
         {
             return GetAsync(storage, artistIds).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Получение треков исполнителя с пагинацией
+        /// <remarks>
+        /// Треки поставляются по <paramref name="pageSize"/> штук на страницу,
+        /// для получения всех треков необходимо использовать метод <see cref="GetAllTracks"/> 
+        /// </remarks>
+        /// </summary>
+        /// <param name="storage">Хранилище</param>
+        /// <param name="artistId">Идентификатор исполнителя</param>
+        /// <param name="page">Страница ответов</param>
+        /// <param name="pageSize">Количество треков на странице ответов</param>
+        public YResponse<YTracksContainer> GetTracks(AuthStorage storage, string artistId, int page = 0,
+            int pageSize = 20)
+        {
+            return GetTracksAsync(storage, artistId, page, pageSize).GetAwaiter().GetResult();
+        }
+        
+        /// <summary>
+        /// Получение всех треков исполнителя
+        /// </summary>
+        /// <param name="storage">Хранилище</param>
+        /// <param name="artistId">Идентификатор исполнителя</param>
+        public YResponse<YTracksContainer> GetAllTracks(AuthStorage storage, string artistId)
+        {
+            return GetAllTracksAsync(storage, artistId).GetAwaiter().GetResult();
         }
 
         #endregion Основные функции

--- a/src/Yandex.Music.Api/API/YArtistAPIAsync.cs
+++ b/src/Yandex.Music.Api/API/YArtistAPIAsync.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Yandex.Music.Api.Common;
 using Yandex.Music.Api.Models.Artist;
 using Yandex.Music.Api.Models.Common;
+using Yandex.Music.Api.Models.Track;
 using Yandex.Music.Api.Requests.Artist;
 
 namespace Yandex.Music.Api.API
@@ -24,7 +25,6 @@ namespace Yandex.Music.Api.API
         /// </summary>
         /// <param name="storage">Хранилище</param>
         /// <param name="artistId">Идентификатор</param> 
-        /// <returns></returns>
         public Task<YResponse<YArtistBriefInfo>> GetAsync(AuthStorage storage, string artistId)
         {
             return new YGetArtistBuilder(api, storage)
@@ -37,12 +37,41 @@ namespace Yandex.Music.Api.API
         /// </summary>
         /// <param name="storage">Хранилище</param>
         /// <param name="artistIds">Идентификаторы</param> 
-        /// <returns></returns>
         public Task<YResponse<List<YArtist>>> GetAsync(AuthStorage storage, IEnumerable<string> artistIds)
         {
             return new YGetArtistsBuilder(api, storage)
                 .Build(artistIds)
                 .GetResponseAsync();
+        }
+
+        /// <summary>
+        /// Получение треков исполнителя с пагинацией
+        /// <remarks>
+        /// Треки поставляются по <paramref name="pageSize"/> штук на страницу,
+        /// для получения всех треков необходимо использовать метод <see cref="GetAllTracksAsync"/> 
+        /// </remarks>
+        /// </summary>
+        /// <param name="storage">Хранилище</param>
+        /// <param name="artistId">Идентификатор исполнителя</param>
+        /// <param name="page">Страница ответов</param>
+        /// <param name="pageSize">Количество треков на странице ответов</param>
+        public Task<YResponse<YTracksContainer>> GetTracksAsync(AuthStorage storage, string artistId, int page = 0,
+            int pageSize = 20)
+        {
+            return new YGetArtistTrackBuilder(api, storage)
+                .Build((artistId, page, pageSize))
+                .GetResponseAsync();
+        }
+
+        /// <summary>
+        /// Получение всех треков исполнителя
+        /// </summary>
+        /// <param name="storage">Хранилище</param>
+        /// <param name="artistId">Идентификатор исполнителя</param>
+        public async Task<YResponse<YTracksContainer>> GetAllTracksAsync(AuthStorage storage, string artistId)
+        {
+            YResponse<YArtistBriefInfo> response = await GetAsync(storage, artistId);
+            return await GetTracksAsync(storage, artistId, pageSize: response.Result.Artist.Counts.Tracks);
         }
 
         #endregion Основные функции

--- a/src/Yandex.Music.Api/Common/Providers/DefaultRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/DefaultRequestProvider.cs
@@ -22,13 +22,20 @@ namespace Yandex.Music.Api.Common.Providers
             if (ex is not WebException webException) 
                 return ex;
 
-            using StreamReader sr = new(webException.Response.GetResponseStream());
-            string result = sr.ReadToEnd();
+            if (webException.Response is null)
+                return ex;
 
+            Stream s = webException.Response.GetResponseStream();
+            if (s is null)
+                return ex;
 
-            YErrorResponse exception = JsonConvert.DeserializeObject<YErrorResponse>(result);
+            using (StreamReader sr = new StreamReader(s)) {
+                string result = sr.ReadToEnd();
+                
+                YErrorResponse exception = JsonConvert.DeserializeObject<YErrorResponse>(result);
 
-            return exception ?? ex;
+                return exception ?? ex;
+            }
         }
 
         #endregion Вспомогательные функции

--- a/src/Yandex.Music.Api/Models/Common/YTrackSource.cs
+++ b/src/Yandex.Music.Api/Models/Common/YTrackSource.cs
@@ -10,6 +10,9 @@ namespace Yandex.Music.Api.Models.Common
         
         [EnumMember(Value = "UGC")]
         [Description("User Generated Content")]
-        UGC
+        UGC,
+        
+        [EnumMember(Value = "OWN_REPLACED_TO_UGC")]
+        OwnReplacedToUGC,
     }
 }

--- a/src/Yandex.Music.Api/Models/Track/YTracksContainer.cs
+++ b/src/Yandex.Music.Api/Models/Track/YTracksContainer.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+
+using Yandex.Music.Api.Models.Common;
+
+namespace Yandex.Music.Api.Models.Track
+{
+    public class YTracksContainer: YBaseModel
+    {
+        [JsonProperty("pager")]
+        public YPager Pager { get; set; }
+        
+        [JsonProperty("tracks")]
+        public List<YTrack> Tracks { get; set; }
+    }
+}

--- a/src/Yandex.Music.Api/Requests/Artist/YGetArtistTrackBuilder.cs
+++ b/src/Yandex.Music.Api/Requests/Artist/YGetArtistTrackBuilder.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Net;
+
+using Yandex.Music.Api.Common;
+using Yandex.Music.Api.Models.Common;
+using Yandex.Music.Api.Models.Track;
+using Yandex.Music.Api.Requests.Common;
+
+namespace Yandex.Music.Api.Requests.Artist
+{
+    [YApiRequest(WebRequestMethods.Http.Get, "artists/{artistId}/tracks")]
+    public class YGetArtistTrackBuilder: YRequestBuilder<YResponse<YTracksContainer>, (string id, int page, int pageSize)>
+    {
+        public YGetArtistTrackBuilder(YandexMusicApi yandex, AuthStorage auth) : base(yandex, auth) { }
+
+        protected override Dictionary<string, string> GetSubstitutions((string id, int page, int pageSize) tuple)
+        {
+            return new Dictionary<string, string> {
+                { "artistId", tuple.id },
+            };
+        }
+
+        protected override NameValueCollection GetQueryParams((string id, int page, int pageSize) tuple)
+        {
+            return new NameValueCollection {
+                { "page", tuple.page.ToString() },
+                { "pageSize", tuple.pageSize.ToString() },
+            };
+        }
+    }
+}


### PR DESCRIPTION
Добавлена обработка эндпоинта "artists/{artistId}/tracks" для получения списка треков исполнителя через метод Artist.GetTracks

Эндпоинт требует пагинации по умолчанию, поэтому реализован метод Artist.GetAllTracks, который получает все треки исполнителя

Добавлены тесты, покрывающие эти методы

Методы добавлены в документацию