### PR TITLE
Обновление модели и исправление опечатки.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # История изменений
 
 ## 2.0.0
-* Добавлена базовая поддержка Унисон. Спасибо ([BloodyBaRGaIn](https://github.com/asnct)) за gist с примером подключения.
+* Добавлена базовая поддержка Унисон. Спасибо ([Yaroslav](https://github.com/asnct)) за gist с примером подключения.
 ## 1.10.1
 * Актуализированы модели. (feat. [BloodyBaRGaIn](https://github.com/BloodyBaRGaIn))
 ## 1.10.0

--- a/src/Yandex.Music.Api/Models/Account/YShortAccountInfo.cs
+++ b/src/Yandex.Music.Api/Models/Account/YShortAccountInfo.cs
@@ -66,6 +66,9 @@ namespace Yandex.Music.Api.Models.Account
         [JsonProperty("has_family")]
         public bool HasFamily { get; set; }
 
+        [JsonProperty("secure_phone_number")]
+        public string SequrePhoneNumber { get; set; }
+
         [JsonProperty("x_token_client_id")]
         public string XTokenClientId { get; set; }
 


### PR DESCRIPTION
После выполнения запросов для получения информации об аккаунте в выходном каталоге в файле логов следующее предупреждение:
```
1-bundle-account-short_info.json:
	Could not find member 'secure_phone_number' on object of type 'YShortAccountInfo'. 
		Path 'secure_phone_number', line 1, position 701.
```
Добавил свойство с соответствующим атрибутом.
Исправил опечатку в гипертексте CHANGELOG.md (на всякий случай разделил эти действия на два коммита).
