### PR TITLE
Дополнение модели YShortAccountInfo.

### DIFF
--- a/src/Yandex.Music.Api/Models/Account/YShortAccountInfo.cs
+++ b/src/Yandex.Music.Api/Models/Account/YShortAccountInfo.cs
@@ -66,6 +66,12 @@ namespace Yandex.Music.Api.Models.Account
         [JsonProperty("has_family")]
         public bool HasFamily { get; set; }
 
+        [JsonProperty("picture_login_forbidden")]
+        public bool PictureLoginForbidden { get; set; }
+
+        [JsonProperty("can_account_join_master")]
+        public bool CanAccountJoinMaster { get; set; }
+
         [JsonProperty("secure_phone_number")]
         public string SecurePhoneNumber { get; set; }
 


### PR DESCRIPTION
Дополнение модели полями на основании логов и результатов выполнения запроса.

Лог:
```
2025-04-28 10-12-50.724 1-bundle-account-short_info.json:
	Could not find member 'picture_login_forbidden' on object of type 'YShortAccountInfo'. 
		Path 'picture_login_forbidden', line 1, position 583.
	Could not find member 'can_account_join_master' on object of type 'YShortAccountInfo'. 
		Path 'can_account_join_master', line 1, position 756.
```

Результат запроса:
```
{
...
"picture_login_forbidden": true,
...
"can_account_join_master": true
}