### PR TITLE
Проброс HttpCompletionOption для получения потока

### DIFF
--- a/src/Yandex.Music.Api/API/YTrackAPI.cs
+++ b/src/Yandex.Music.Api/API/YTrackAPI.cs
@@ -227,10 +227,12 @@ namespace Yandex.Music.Api.API
         /// </summary>
         /// <param name="storage">Хранилище</param>
         /// <param name="trackKey">Ключ трека в формате {идентификатор трека:идентификатор альбома}</param>
+        /// <param name="httpCompletionOption">Параметры передачи управления при http запросе</param>
         /// <returns></returns>
-        public Stream ExtractStream(AuthStorage storage, string trackKey)
+        public Stream ExtractStream(AuthStorage storage, string trackKey,
+            HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
-            return ExtractStreamAsync(storage, trackKey).GetAwaiter().GetResult();
+            return ExtractStreamAsync(storage, trackKey, httpCompletionOption).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -238,10 +240,12 @@ namespace Yandex.Music.Api.API
         /// </summary>
         /// <param name="storage">Хранилище</param>
         /// <param name="track">Трек</param>
+        /// <param name="httpCompletionOption">Параметры передачи управления при http запросе</param>
         /// <returns></returns>
-        public Stream ExtractStream(AuthStorage storage, YTrack track)
+        public Stream ExtractStream(AuthStorage storage, YTrack track,
+            HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
-            return ExtractStreamAsync(storage, track.GetKey().ToString()).GetAwaiter().GetResult();
+            return ExtractStreamAsync(storage, track.GetKey().ToString(), httpCompletionOption).GetAwaiter().GetResult();
         }
 
         #endregion В поток

--- a/src/Yandex.Music.Api/API/YTrackAPI.cs
+++ b/src/Yandex.Music.Api/API/YTrackAPI.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 
 using Yandex.Music.Api.Common;
 using Yandex.Music.Api.Models.Common;

--- a/src/Yandex.Music.Api/API/YTrackAPIAsync.cs
+++ b/src/Yandex.Music.Api/API/YTrackAPIAsync.cs
@@ -302,7 +302,7 @@ namespace Yandex.Music.Api.API
         public Task<Stream> ExtractStreamAsync(AuthStorage storage, YTrack track,
             HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
-            return ExtractStreamAsync(storage, track.GetKey().ToString());
+            return ExtractStreamAsync(storage, track.GetKey().ToString(), httpCompletionOption);
         }
 
         #endregion В поток

--- a/src/Yandex.Music.Api/API/YTrackAPIAsync.cs
+++ b/src/Yandex.Music.Api/API/YTrackAPIAsync.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using System.Net.Http;
 
 using Yandex.Music.Api.Common;
 using Yandex.Music.Api.Models.Common;
@@ -282,11 +283,13 @@ namespace Yandex.Music.Api.API
         /// </summary>
         /// <param name="storage">Хранилище</param>
         /// <param name="trackKey">Ключ трека в формате {идентификатор трека:идентификатор альбома}</param>
+        /// <param name="httpCompletionOption">Параметры передачи управления при http запросе</param>
         /// <returns></returns>
-        public async Task<Stream> ExtractStreamAsync(AuthStorage storage, string trackKey)
+        public async Task<Stream> ExtractStreamAsync(AuthStorage storage, string trackKey,
+            HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             string url = await GetFileLinkAsync(storage, trackKey);
-            return await new DataDownloader(storage).AsStream(url);
+            return await new DataDownloader(storage).AsStream(url, httpCompletionOption);
         }
 
         /// <summary>
@@ -294,8 +297,10 @@ namespace Yandex.Music.Api.API
         /// </summary>
         /// <param name="storage">Хранилище</param>
         /// <param name="track">Трек</param>
+        /// <param name="httpCompletionOption">Параметры передачи управления при http запросе</param>
         /// <returns></returns>
-        public Task<Stream> ExtractStreamAsync(AuthStorage storage, YTrack track)
+        public Task<Stream> ExtractStreamAsync(AuthStorage storage, YTrack track,
+            HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             return ExtractStreamAsync(storage, track.GetKey().ToString());
         }

--- a/src/Yandex.Music.Api/Common/DataDownloader.cs
+++ b/src/Yandex.Music.Api/Common/DataDownloader.cs
@@ -12,17 +12,17 @@ namespace Yandex.Music.Api.Common
     {
         private AuthStorage authStorage;
 
-        private async Task<HttpContent> GetResponseContent(string url)
+        private async Task<HttpContent> GetResponseContent(string url, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             HttpRequestMessage message = new(new HttpMethod(WebRequestMethods.Http.Get), url);
 
-            HttpResponseMessage response = await authStorage.Provider.GetWebResponseAsync(message);
+            HttpResponseMessage response = await authStorage.Provider.GetWebResponseAsync(message, httpCompletionOption);
             return response.Content;
         }
 
-        public async Task<Stream> AsStream(string url)
+        public async Task<Stream> AsStream(string url, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
-            HttpContent content = await GetResponseContent(url);
+            HttpContent content = await GetResponseContent(url, httpCompletionOption);
             return await content.ReadAsStreamAsync();
         }
 

--- a/src/Yandex.Music.Api/Common/Providers/CommonRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/CommonRequestProvider.cs
@@ -33,6 +33,11 @@ namespace Yandex.Music.Api.Common.Providers
             throw new NotImplementedException();
         }
 
+        public virtual Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message, HttpCompletionOption completionOption)
+        {
+            throw new NotImplementedException();
+        }
+
         public virtual async Task<T> GetDataFromResponseAsync<T>(YandexMusicApi api, HttpResponseMessage response)
         {
             string result = await response.Content.ReadAsStringAsync();

--- a/src/Yandex.Music.Api/Common/Providers/CommonRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/CommonRequestProvider.cs
@@ -28,12 +28,7 @@ namespace Yandex.Music.Api.Common.Providers
 
         #region IRequestProvider
 
-        public virtual Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message)
-        {
-            throw new NotImplementedException();
-        }
-
-        public virtual Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message, HttpCompletionOption completionOption)
+        public virtual Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
             throw new NotImplementedException();
         }

--- a/src/Yandex.Music.Api/Common/Providers/DefaultRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/DefaultRequestProvider.cs
@@ -49,13 +49,8 @@ namespace Yandex.Music.Api.Common.Providers
 
         #region IRequestProvider
 
-        public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message)
-        {
-            return GetWebResponseAsync(message, HttpCompletionOption.ResponseContentRead);
-        }
-
         public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message,
-            HttpCompletionOption completionOption)
+            HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
             try
             {

--- a/src/Yandex.Music.Api/Common/Providers/DefaultRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/DefaultRequestProvider.cs
@@ -51,6 +51,12 @@ namespace Yandex.Music.Api.Common.Providers
 
         public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message)
         {
+            return GetWebResponseAsync(message, HttpCompletionOption.ResponseContentRead);
+        }
+
+        public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message,
+            HttpCompletionOption completionOption)
+        {
             try
             {
                 HttpClient client = new(new SocketsHttpHandler {
@@ -60,7 +66,7 @@ namespace Yandex.Music.Api.Common.Providers
                     CookieContainer = storage.Context.Cookies,
                 });
 
-                return client.SendAsync(message);
+                return client.SendAsync(message, completionOption);
             }
             catch (Exception ex)
             {

--- a/src/Yandex.Music.Api/Common/Providers/IRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/IRequestProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http;
+﻿﻿using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Yandex.Music.Api.Common.Providers
@@ -14,6 +14,14 @@ namespace Yandex.Music.Api.Common.Providers
         /// <param name="message">Запрос</param>
         /// <returns></returns>
         Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message);
+
+        /// <summary>
+        /// Функция получения ответа с опциями завершения
+        /// </summary>
+        /// <param name="message">Запрос</param>
+        /// <param name="completionOption">Опция завершения запроса</param>
+        /// <returns></returns>
+        Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead);
 
         /// <summary>
         /// Функция формирования ответа

--- a/src/Yandex.Music.Api/Common/Providers/IRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/IRequestProvider.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Yandex.Music.Api.Common.Providers
@@ -10,13 +10,6 @@ namespace Yandex.Music.Api.Common.Providers
     {
         /// <summary>
         /// Функция получения ответа
-        /// </summary>
-        /// <param name="message">Запрос</param>
-        /// <returns></returns>
-        Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message);
-
-        /// <summary>
-        /// Функция получения ответа с опциями завершения
         /// </summary>
         /// <param name="message">Запрос</param>
         /// <param name="completionOption">Опция завершения запроса</param>

--- a/src/Yandex.Music.Api/Common/Providers/MockRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/MockRequestProvider.cs
@@ -25,6 +25,11 @@ namespace Yandex.Music.Api.Common.Providers
             throw new NotImplementedException();
         }
 
+        public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message, HttpCompletionOption completionOption)
+        {
+            throw new NotImplementedException();
+        }
+
         #endregion IRequestProvider
     }
 }

--- a/src/Yandex.Music.Api/Common/Providers/MockRequestProvider.cs
+++ b/src/Yandex.Music.Api/Common/Providers/MockRequestProvider.cs
@@ -20,12 +20,8 @@ namespace Yandex.Music.Api.Common.Providers
 
         #region IRequestProvider
 
-        public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message, HttpCompletionOption completionOption)
+        public override Task<HttpResponseMessage> GetWebResponseAsync(HttpRequestMessage message,
+            HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Загружаем только заголовки и сразу же отдаём стрим, чтобы быстрей начать отдавать контент.

Согласно документации:
<img width="969" height="291" alt="image" src="https://github.com/user-attachments/assets/3dd93d3c-f825-4621-aadb-a66b87e48a43" />

На моих тестах вот так вот получилось:

До
[Timing] ExtractStreamAsync: 4147 ms
После
[Timing] ExtractStreamAsync: 610 ms
